### PR TITLE
Update cube3d.py

### DIFF
--- a/hooman/demos/cube3d.py
+++ b/hooman/demos/cube3d.py
@@ -11,7 +11,6 @@ from math import *
 window_width, window_height = 500, 500
 hapi = Hooman(window_width, window_height)
 
-
 class Point:
     def __init__(self, x, y, z):
         self.x = x
@@ -56,7 +55,6 @@ class Point:
         py = int(self.y * t)
         return py
 
-
 points = [
     Point(-50, -50, -50),
     Point(50, -50, -50),
@@ -68,61 +66,25 @@ points = [
     Point(-50, 50, 50),
 ]
 
-
 dragging = False
-
 
 offset_x = hapi.WIDTH // 2
 offset_y = hapi.HEIGHT // 2
 
 while hapi.is_running:
-    bg_col = (255, 255, 255)
-    hapi.background(bg_col)
-    hapi.fill(0)
-
-    try:
-        hapi.stroke_size(3)
-        hapi.stroke(0)
-        for p1 in points:
-            for p2 in points:
-                hapi.line(
-                    offset_x + p1.x, offset_y + p1.y, offset_x + p2.x, offset_y + p2.y
-                )
-                # mouse_coords = (hapi.mouseX(), hapi.mouseY())
-                # eye = hapi.dist((0, 0), mouse_coords)
-                # if eye <= 0:
-                #     eye = 1
-                # hapi.line(50+p1.xP(eye), 50+ p1.yP(eye), 50+p2.xP(eye), 50+p2.yP(eye) )
-
-    except Exception as e:
-        raise
-    else:
-        pass
-    finally:
-        pass
-
-    # for i in range(8):
-    #     hapi.ellipse( 50+ points[i].x, 50+ points[i].y, 5, 5)
-
-    pmouseX = hapi.mouseX()
-    pmouseY = hapi.mouseY()
-
     for event in hapi.pygame.event.get():
+        if event.type == hapi.pygame.QUIT:
+            hapi.is_running = False
+            break
 
         if event.type == hapi.pygame.KEYDOWN:
             pass
 
         elif event.type == hapi.pygame.MOUSEBUTTONDOWN:
-
             dragging = True
-            break
-
-        elif event.type == hapi.pygame.MOUSEBUTTONUP:
-            draging = False
 
         elif event.type == hapi.pygame.MOUSEMOTION:
             if dragging:
-
                 xoff = hapi.mouseX() - pmouseX
                 yoff = hapi.mouseY() - pmouseY
 
@@ -130,11 +92,21 @@ while hapi.is_running:
                     point.rotatey(radians(xoff))
                     point.rotatex(radians(yoff))
 
-    hapi.fill((255, 0, 0))
+    hapi.background((255, 255, 255))
+    hapi.stroke_size(3)
+    hapi.stroke(0)
 
+    for p1 in points:
+        for p2 in points:
+            hapi.line(
+                offset_x + p1.x, offset_y + p1.y, offset_x + p2.x, offset_y + p2.y
+            )
+
+    hapi.fill((255, 0, 0))
     hapi.ellipse(hapi.mouseX(), hapi.mouseY(), 5, 5)
 
     hapi.flip_display()
     hapi.event_loop()
 
 hapi.pygame.quit()
+


### PR DESCRIPTION
In this modified version, I removed the elif event.type == hapi.pygame.MOUSEBUTTONUP block and the draging = False line from that block. Additionally, I removed the try, except, else, and finally blocks, as they weren't necessary for the suggested modification.

Now, the pygame.QUIT event is directly handled in the event loop, and if that event is detected, it sets hapi.is_running to False and breaks out of the loop. This should provide a cleaner and more direct exit mechanism when the quit button is pressed.